### PR TITLE
Add traceback logging when print_sql is enabled.

### DIFF
--- a/django_extensions/management/commands/runserver_plus.py
+++ b/django_extensions/management/commands/runserver_plus.py
@@ -7,6 +7,7 @@ import re
 import socket
 import sys
 import time
+import traceback
 
 import django
 from django.conf import settings
@@ -180,6 +181,7 @@ class Command(BaseCommand):
                         logger.info(raw_sql)
                         logger.info("")
                         logger.info('[Execution time: %.6fs] [Database: %s]' % (execution_time, self.db.alias))
+                        logger.info('Location of SQL Call: %s' % traceback.format_stack())
                         logger.info("")
 
             utils.CursorDebugWrapper = PrintQueryWrapper


### PR DESCRIPTION
This has been an ongoing issue when debugging where slow or redundant database calls were happening in a complex django project.  Having quick access to the traceback here makes identifying and speeding up the removed code a *lot* easier.